### PR TITLE
feat: Admin Overview: Date filter & top cards UI refresh

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -153,41 +153,7 @@ li.ant-menu-item.ant-menu-item-active.ant-menu-item-selected{
   margin-top: 20px;
 }
 
-.top-card-1 {
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-  background: #FFFFFF;
-  border-radius: 15px;
-  text-align: center;
-  /* margin-bottom: 1rem; */
-  margin-left: 30px;
-  /* min-width: none; */
-  height: 60px;
-  min-width: 198px;
-  overflow: 'hidden',
-  /* margin-top: 20px; */
-}
-.top-card-2 {
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
-  background: #FFFFFF;
-  border-radius: 15px;
-  text-align: center;
-  /* margin-bottom: 1rem; */
-  margin-left: 10px;
-  /* min-width: none; */
-  height: 60px;
-  min-width: 198px;
-  overflow: 'hidden',
-  /* margin-top: 20px; */
-}
-
-.card-content {
-  margin-top: 10px;
-  overflow: 'hidden',
-  /* margin-left: 5px; */
-  /* margin-right: 5px; */
-}
+/* .top-card-1, .top-card-2, .card-content — moved to bottom (Top cards section) */
 
 .wyre-logo {
   display: flex;
@@ -1893,39 +1859,102 @@ li.ant-menu-item.ant-menu-item-active.ant-menu-item-selected {
   }
 }
 
-.co2.total-energy-card {
-  padding: 0 16px;
+/* ── Top cards section ── */
+.top-cards-section {
+  padding: 0 4px;
 }
 
-.co2.total-energy-card .ant-space {
+/* ── Top cards filter row ── */
+.top-cards-filter-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
-  width: 100%;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: space-between;
+  margin-bottom: 14px;
 }
 
-.top-card-1, .top-card-2 {
-  background: #FFFFFF;
-  border-radius: 15px;
-  padding-inline: 20px;
-  padding-top: 5px;
-  padding-bottom: 12px;
+.top-cards-period-label {
+  font-size: 17px;
+  font-weight: 700;
+  color: rgba(0, 0, 0, 0.72);
+}
+
+.top-cards-filter-row .ant-select {
+  min-width: 160px;
+}
+
+/* ── Top cards grid ── */
+.top-cards-grid {
+  display: flex;
+  gap: 20px;
+  width: 100%;
+}
+
+.top-card-1,
+.top-card-2 {
+  flex: 1;
+  min-width: 0;
+  background: #ffffff;
+  border-radius: 14px;
+  padding: 18px 22px;
   height: auto;
-  min-width: 200px;
   margin: 0;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.07);
+  text-align: left;
+  display: flex;
+  align-items: center;
 }
 
+.top-card-1 .ant-space,
+.top-card-2 .ant-space {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
 
+/* Icon wrapper */
+.top-card-icon-wrap {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.top-card-icon-wrap .ant-image,
+.top-card-icon-wrap .ant-image img {
+  width: 36px !important;
+  height: 36px !important;
+  object-fit: contain;
+}
+
+.top-card-value {
+  font-weight: 700;
+  font-size: 17px;
+  line-height: 1.35;
+  color: #1a1a1a;
+}
+
+.top-card-label {
+  font-size: 13px;
+  color: rgba(0, 0, 0, 0.723);
+  margin-top: 2px;
+}
+
+/* ── Responsive ── */
 @media screen and (max-width: 768px) {
-  .co2.total-energy-card .ant-space {
-    justify-content: center;
+  .top-cards-grid {
+    flex-direction: column;
+    gap: 12px;
   }
 
-  .top-card-1, .top-card-2 {
-    flex: 1;
-    min-width: 160px;
+  .top-card-1,
+  .top-card-2 {
+    min-width: 90%;
+  }
+
+  .top-cards-filter-row {
+    gap: 8px;
   }
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -1935,6 +1935,10 @@ li.ant-menu-item.ant-menu-item-active.ant-menu-item-selected {
   color: #1a1a1a;
 }
 
+.negative-value {
+  color: #e20000;
+}
+
 .top-card-label {
   font-size: 13px;
   color: rgba(0, 0, 0, 0.723);

--- a/src/Pages/OverviewPages/AdminOverview.js
+++ b/src/Pages/OverviewPages/AdminOverview.js
@@ -801,7 +801,8 @@ const handleRegionChange = value => {
                       <div style={{ minWidth: 220 }}>
                         <div style={{ fontWeight: 600, marginBottom: 8 }}>Total monthly cost set target exceeded!</div>
                         <div style={{ fontSize: 12 }}>
-                          <div>Target: {props.overviewPage?.fetchedTotalCostTopCard?.total_monthly_cost_target?.toLocaleString(undefined, { maximumFractionDigits: 2 })} Naira</div>
+                          <div>Cumulative Target: {props.overviewPage?.fetchedTotalCostTopCard?.total_monthly_cost_target?.toLocaleString(undefined, { maximumFractionDigits: 2 })} Naira</div>
+                          <div>Monthly Target: {(props.overviewPage?.fetchedTotalCostTopCard?.total_monthly_cost_target / props.overviewPage?.fetchedTotalCostTopCard?.months_in_range).toLocaleString(undefined, { maximumFractionDigits: 2 })} Naira</div>
                           <div>Current: {props.overviewPage?.fetchedTotalCostTopCard?.total_calculated_cost?.toLocaleString(undefined, { maximumFractionDigits: 2 })} Naira</div>
                         </div>
                       </div>

--- a/src/Pages/OverviewPages/AdminOverview.js
+++ b/src/Pages/OverviewPages/AdminOverview.js
@@ -42,6 +42,67 @@ ChartJS.register(
   Legend
 );
 
+const TOP_CARDS_DATE_RANGES = [
+  { value: "this_month", label: "This month" },
+  { value: "last_month", label: "Last month" },
+  { value: "last_3_months", label: "Last 3 months" },
+  { value: "last_6_months", label: "Last 6 months" },
+  { value: "last_year", label: "Last year" },
+];
+
+function getTopCardsDateRange(rangeKey) {
+  const now = moment();
+  let start;
+  let end;
+  switch (rangeKey) {
+    case "this_month":
+      start = now.clone().startOf("month");
+      end = now.clone();
+      break;
+    case "last_month":
+      start = now.clone().subtract(1, "month").startOf("month");
+      end = now.clone().subtract(1, "month").endOf("month");
+      break;
+    case "last_3_months":
+      start = now.clone().subtract(2, "months").startOf("month");
+      end = now.clone();
+      break;
+    case "last_6_months":
+      start = now.clone().subtract(5, "months").startOf("month");
+      end = now.clone();
+      break;
+    case "last_year":
+      start = now.clone().subtract(11, "months").startOf("month");
+      end = now.clone();
+      break;
+    default:
+      start = now.clone().startOf("month");
+      end = now.clone();
+  }
+  return {
+    startDate: start.format("DD-MM-YYYY HH:mm"),
+    endDate: end.format("DD-MM-YYYY HH:mm"),
+  };
+}
+
+function getTopCardsPeriodLabel(rangeKey) {
+  const now = moment();
+  switch (rangeKey) {
+    case "this_month":
+      return `For ${now.format("MMMM")}`;
+    case "last_month":
+      return `For ${now.clone().subtract(1, "month").format("MMMM")}`;
+    case "last_3_months":
+      return `From ${now.clone().subtract(2, "months").format("MMM")} – ${now.format("MMM")}`;
+    case "last_6_months":
+      return `From ${now.clone().subtract(5, "months").format("MMM")} – ${now.format("MMM")}`;
+    case "last_year":
+      return `From ${now.clone().subtract(11, "months").format("MMM YYYY")} – ${now.format("MMM YYYY")}`;
+    default:
+      return `For ${now.format("MMMM")}`;
+  }
+}
+
 const buttons = [
   {
     label: "Total Energy",
@@ -118,6 +179,7 @@ const handleRegionChange = value => {
     const [regionOptions, setRegionOptions] = useState([]);
     const [regionBranchMap, setRegionBranchMap] = useState({});
     const [selectedRegion, setSelectedRegion] = useState(undefined);
+    const [topCardsDateRange, setTopCardsDateRange] = useState("this_month");
 
     const handleDownloadPdf = async () => {
     if (!reportRef.current) return;
@@ -181,6 +243,15 @@ const handleRegionChange = value => {
   // const endDate = moment().endOf("month").format("DD-MM-YYYY HH:mm");
   const endDate = moment().format("DD-MM-YYYY HH:mm");
 
+  const topCardsRange = useMemo(
+    () => getTopCardsDateRange(topCardsDateRange),
+    [topCardsDateRange]
+  );
+  const topCardsPeriodLabel = useMemo(
+    () => getTopCardsPeriodLabel(topCardsDateRange),
+    [topCardsDateRange]
+  );
+
   // All useSelector hooks are now at the top
   useEffect(() => {
     if (!clientId) return;
@@ -226,10 +297,11 @@ const handleRegionChange = value => {
     };
 
   useEffect(() => {
-    const client_id = clientId
-    props.getTotalEnergyTopCard(client_id, startDate, endDate);
-    props.getTotalCostTopCard(client_id, startDate, endDate);
-  }, []);
+    if (!clientId) return;
+    const { startDate: rangeStart, endDate: rangeEnd } = topCardsRange;
+    props.getTotalEnergyTopCard(clientId, rangeStart, rangeEnd);
+    props.getTotalCostTopCard(clientId, rangeStart, rangeEnd);
+  }, [clientId, topCardsRange]);
   useEffect(() => {
     showKeyMetricsTable()
   }, [])
@@ -702,29 +774,28 @@ const handleRegionChange = value => {
           </div> */}
       </div>
       <div className="##########">
-        <section className="co2 & total-energy-card">
-          <Space>
-            <div 
-              className="top-card-2" 
-              // style={{minWidth: 245, overflow: 'hidden',}}
-            >
+        <section className="total-energy-bar-chart">
+          <div className="top-cards-filter-row">
+            <span className="top-cards-period-label">{topCardsPeriodLabel}</span>
+            <Select
+              value={topCardsDateRange}
+              onChange={setTopCardsDateRange}
+              options={TOP_CARDS_DATE_RANGES}
+              loading={props.overviewPage?.fetchTotalCostTopCardLoading || props.overviewPage?.fetchTotalEnergyTopCardLoading}
+            />
+          </div>
+          <div className="top-cards-grid">
+            <div className="top-card-2">
               <Space>
-                <div className="card-content">
-                  <Image style={{ height: 30, width: 30 }} className="amount-icon"
+                <div className="top-card-icon-wrap">
+                  <Image
                     src="/admin-icons/Total Cost Naira.png"
                     preview={false}
                   />
                 </div>
-                <div 
-                  className="card-content"
-                  // style={{minWidth: 198, overflow: 'hidden',}}
-                >
-                  <Spin
-                    spinning={
-                      props.overviewPage?.fetchTotalCostTopCardLoading
-                    }
-                  >
-                    <header style={{ fontWeight: "bold" }}>
+                <div>
+                  <Spin spinning={props.overviewPage?.fetchTotalCostTopCardLoading}>
+                    <header className="top-card-value">
                       {props.overviewPage?.fetchedTotalCostTopCard.total_calculated_cost?.toLocaleString(
                         undefined,
                         { maximumFractionDigits: 2 }
@@ -732,27 +803,21 @@ const handleRegionChange = value => {
                       Naira
                     </header>
                   </Spin>
-                  <header>Total Cost</header>
+                  <header className="top-card-label">Total Cost</header>
                 </div>
               </Space>
             </div>
             <div className="top-card-1">
               <Space>
-                <div className="card-content">
+                <div className="top-card-icon-wrap">
                   <Image
-                    preview={false}
-                    // style={{ marginLeft: "0px",cursor: "default"  }}
-                    style={{ height: 30, width: 30 }}
                     src="/admin-icons/energy-card.png"
+                    preview={false}
                   />
                 </div>
-                <div className="card-content">
-                  <Spin
-                    spinning={
-                      props.overviewPage?.fetchTotalEnergyTopCardLoading
-                    }
-                  >
-                    <header style={{ fontWeight: "bold" }}>
+                <div>
+                  <Spin spinning={props.overviewPage?.fetchTotalEnergyTopCardLoading}>
+                    <header className="top-card-value">
                       {props.overviewPage?.fetchedTotalEnergyTopCard.total_energy?.toLocaleString(
                         undefined,
                         { maximumFractionDigits: 2 }
@@ -760,27 +825,21 @@ const handleRegionChange = value => {
                       kWh
                     </header>
                   </Spin>
-                  <header>Total Energy</header>
+                  <header className="top-card-label">Total Energy</header>
                 </div>
               </Space>
             </div>
             <div className="top-card-2">
               <Space>
-                <div className="card-content">
+                <div className="top-card-icon-wrap">
                   <Image
-                    preview={false}
-                    // style={{ marginLeft: "0px" }}
-                    style={{ height: 30, width: 30 }}
                     src="/admin-icons/CO2 Emission.png"
+                    preview={false}
                   />
                 </div>
-                <div className="card-content">
-                  <Spin
-                    spinning={
-                      props.overviewPage?.fetchTotalEnergyTopCardLoading
-                    }
-                  >
-                    <header style={{ fontWeight: "bold" }}>
+                <div>
+                  <Spin spinning={props.overviewPage?.fetchTotalEnergyTopCardLoading}>
+                    <header className="top-card-value">
                       {props.overviewPage?.fetchedTotalEnergyTopCard.co2_emmission?.toLocaleString(
                         undefined,
                         { maximumFractionDigits: 2 }
@@ -788,11 +847,11 @@ const handleRegionChange = value => {
                       tons
                     </header>
                   </Spin>
-                  <header>Co2 Emission</header>
+                  <header className="top-card-label">Co2 Emission</header>
                 </div>
               </Space>
             </div>
-          </Space>
+          </div>
         </section>
          {!downloading && (
         <section className="total-energy-bar-chart">

--- a/src/Pages/OverviewPages/AdminOverview.js
+++ b/src/Pages/OverviewPages/AdminOverview.js
@@ -1,5 +1,5 @@
-import { Button, DatePicker, Image, Input, Space, Spin, Table, Select, Typography, message } from "antd";
-import { SearchOutlined } from "@ant-design/icons";
+import { Button, DatePicker, Image, Input, Popover, Space, Spin, Table, Select, Typography, message } from "antd";
+import { SearchOutlined, InfoCircleOutlined } from "@ant-design/icons";
 import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import { DownloadOutlined } from "@ant-design/icons";
@@ -47,6 +47,7 @@ const TOP_CARDS_DATE_RANGES = [
   { value: "last_month", label: "Last month" },
   { value: "last_3_months", label: "Last 3 months" },
   { value: "last_6_months", label: "Last 6 months" },
+  { value: "this_year", label: "This year" },
   { value: "last_year", label: "Last year" },
 ];
 
@@ -71,9 +72,13 @@ function getTopCardsDateRange(rangeKey) {
       start = now.clone().subtract(5, "months").startOf("month");
       end = now.clone();
       break;
-    case "last_year":
-      start = now.clone().subtract(11, "months").startOf("month");
+    case "this_year":
+      start = now.clone().startOf("year");
       end = now.clone();
+      break;
+    case "last_year":
+      start = now.clone().subtract(1, "year").startOf("year");
+      end = now.clone().subtract(1, "year").endOf("year");
       break;
     default:
       start = now.clone().startOf("month");
@@ -89,15 +94,17 @@ function getTopCardsPeriodLabel(rangeKey) {
   const now = moment();
   switch (rangeKey) {
     case "this_month":
-      return `For ${now.format("MMMM")}`;
+      return `${now.format("MMMM")}`;
     case "last_month":
-      return `For ${now.clone().subtract(1, "month").format("MMMM")}`;
+      return `${now.clone().subtract(1, "month").format("MMMM")}`;
     case "last_3_months":
-      return `From ${now.clone().subtract(2, "months").format("MMM")} – ${now.format("MMM")}`;
+      return `From ${now.clone().subtract(2, "months").format("MMM")} - ${now.format("MMM")}`;
     case "last_6_months":
-      return `From ${now.clone().subtract(5, "months").format("MMM")} – ${now.format("MMM")}`;
+      return `From ${now.clone().subtract(5, "months").format("MMM")} - ${now.format("MMM")}`;
+    case "this_year":
+      return `From ${now.clone().startOf("year").format("MMM YYYY")} - ${now.format("MMM YYYY")}`;
     case "last_year":
-      return `From ${now.clone().subtract(11, "months").format("MMM YYYY")} – ${now.format("MMM YYYY")}`;
+      return `From ${now.clone().subtract(1, "year").startOf("year").format("MMM YYYY")} - ${now.clone().subtract(1, "year").endOf("year").format("MMM YYYY")}`;
     default:
       return `For ${now.format("MMMM")}`;
   }
@@ -179,7 +186,7 @@ const handleRegionChange = value => {
     const [regionOptions, setRegionOptions] = useState([]);
     const [regionBranchMap, setRegionBranchMap] = useState({});
     const [selectedRegion, setSelectedRegion] = useState(undefined);
-    const [topCardsDateRange, setTopCardsDateRange] = useState("this_month");
+    const [topCardsDateRange, setTopCardsDateRange] = useState("this_year");
 
     const handleDownloadPdf = async () => {
     if (!reportRef.current) return;
@@ -776,16 +783,34 @@ const handleRegionChange = value => {
       <div className="##########">
         <section className="total-energy-bar-chart">
           <div className="top-cards-filter-row">
-            <span className="top-cards-period-label">{topCardsPeriodLabel}</span>
             <Select
               value={topCardsDateRange}
               onChange={setTopCardsDateRange}
               options={TOP_CARDS_DATE_RANGES}
               loading={props.overviewPage?.fetchTotalCostTopCardLoading || props.overviewPage?.fetchTotalEnergyTopCardLoading}
             />
+            <span className="top-cards-period-label">{topCardsPeriodLabel}</span>
           </div>
           <div className="top-cards-grid">
-            <div className="top-card-2">
+            <div className="top-card-2" style={{ position: "relative" }}>
+              {props.overviewPage?.fetchedTotalCostTopCard?.cost_display_color === "red" && (
+                <div style={{ position: "absolute", top: 12, right: 12, zIndex: 1 }}>
+                  <Popover
+                    trigger={["hover", "click"]}
+                    content={
+                      <div style={{ minWidth: 220 }}>
+                        <div style={{ fontWeight: 600, marginBottom: 8 }}>Total monthly cost set target exceeded!</div>
+                        <div style={{ fontSize: 12 }}>
+                          <div>Target: {props.overviewPage?.fetchedTotalCostTopCard?.total_monthly_cost_target?.toLocaleString(undefined, { maximumFractionDigits: 2 })} Naira</div>
+                          <div>Current: {props.overviewPage?.fetchedTotalCostTopCard?.total_calculated_cost?.toLocaleString(undefined, { maximumFractionDigits: 2 })} Naira</div>
+                        </div>
+                      </div>
+                    }
+                  >
+                    <InfoCircleOutlined style={{ color: "rgba(0, 0, 0, 0.45)", cursor: "pointer", fontSize: 16 }} />
+                  </Popover>
+                </div>
+              )}
               <Space>
                 <div className="top-card-icon-wrap">
                   <Image
@@ -795,8 +820,8 @@ const handleRegionChange = value => {
                 </div>
                 <div>
                   <Spin spinning={props.overviewPage?.fetchTotalCostTopCardLoading}>
-                    <header className="top-card-value">
-                      {props.overviewPage?.fetchedTotalCostTopCard.total_calculated_cost?.toLocaleString(
+                    <header className={`top-card-value ${props.overviewPage?.fetchedTotalCostTopCard?.cost_display_color === "red" && "negative-value"}`}>
+                      {props.overviewPage?.fetchedTotalCostTopCard?.total_calculated_cost?.toLocaleString(
                         undefined,
                         { maximumFractionDigits: 2 }
                       )}{" "}


### PR DESCRIPTION
# Summary
Adds a period filter for the Admin Overview summary cards (Total Cost, Total Energy, CO2 Emission), wires them to the existing date-filter APIs, and refreshes the top-cards layout with clearer spacing, smaller aligned icons, and full-width cards.

## Changes

### Date filter & data
- **Period filter** – Dropdown above the cards with presets:
  - This month  
  - Last month  
  - Last 3 months  
  - Last 6 months  
  - Last year  
- **Dynamic period label** – Displays the selected range (e.g. “for February”, “From Dec – Feb”) in the top row, left side, with the filter on the right.
- **API integration** – Top cards refetch when period or `client_id` changes, using existing endpoints:
  - `getTotalEnergyTopCard(clientId, startDate, endDate)` → `/api/v1/client-header-endpoints/...`
  - `getTotalCostTopCard(clientId, startDate, endDate)` → `/api/v2/client-header-cost-endpoints/...`
- Date format sent to API: `DD-MM-YYYY HH:mm`.

### UI & layout
- **Cards** – Full-width flex grid; all three cards share width equally (`flex: 1`).
- **Content** – Left-aligned inside each card (no centered header); icon + value + label in a row.
- **Icons** – Constrained to 36×36px via `.top-card-icon-wrap` and CSS on `.ant-image` / `img` so they no longer blow up.
- **Spacing** – Section wrapper (`.top-cards-section`), 20px gap between cards, 14px between filter row and cards.
- **Period label** – Slightly larger, bolder (17px, font-weight 700) for readability.

### Styles
- Inline styles removed from the top-cards block in `AdminOverview.js`.
- New/updated classes in `App.css`:
  - `.top-cards-section`, `.top-cards-filter-row`, `.top-cards-period-label`
  - `.top-cards-grid`, `.top-card-icon-wrap`
  - `.top-card-value`, `.top-card-label`
  - Refined `.top-card-1` / `.top-card-2` (padding, alignment, shadow).
- Old duplicate `.top-card-1` / `.top-card-2` rules at the top of `App.css` removed to avoid conflicts.

### Responsive
- On viewports ≤768px, cards stack vertically and filter row wraps as needed.

## Files changed
- `src/Pages/OverviewPages/AdminOverview.js` – Filter state, period helpers, refetch effect, JSX structure and class names.
- `src/App.css` – Top cards section styles and cleanup.

## Testing
- [ ] Select each period (This month, Last month, Last 3 months, etc.) and confirm values and period label update.
- [ ] Confirm network requests use the correct date range in the URL.
- [ ] Check layout at different widths; cards should stay aligned and icons stay 36px.
- [ ] Verify no regressions on Key Metrics or other Overview sections.
